### PR TITLE
fix docker with custom conf file, fix docker port

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ bloomd is now listening on port `8673` of your localhost.
 
   1. Create a mountable data directory `<data-dir>` on the host.
 
-  2. Create a [bloomd config file](https://github.com/armon/bloomd#configuration-options) at `<data-dir>/bloomd.conf`.
+  2. Create a [bloomd config file](https://github.com/armon/bloomd#configuration-options) at `$DATA_DIR/bloomd.conf`.
 
-    ```ini
-    # Settings for bloomd
-    [bloomd]
-    tcp_port = 8673
-    data_dir = /data/bloomd
-    log_level = INFO
-    flush_interval = 300
-    workers = 2
-    ```
+```ini
+# Settings for bloomd
+[bloomd]
+tcp_port = 8673
+data_dir = /data/bloomd
+log_level = INFO
+flush_interval = 300
+workers = 2
+```
 
   3. Start a container by mounting the data directory on the host to /data in the container:
 
-    ```sh
-    docker run -d -p 8673:8673 -v <data-dir>:/data -v <data-dir>/bloomd.conf:/etc/bloomd/bloomd.conf saidimu/bloomd:v0.7.4
-    ```
+```bash
+docker run -d -p 8673:8673 -v "$DATA_DIR":/data -v "$DATA_DIR"/bloomd.conf:/etc/bloomd/bloomd.conf saidimu/bloomd:v0.7.4
+```
 
 #### Using fig with data-only containers
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bloomd is now listening on port `8673` of your localhost.
   3. Start a container by mounting the data directory on the host to /data in the container:
 
     ```sh
-    docker run -d -p 8673 -v <data-dir>:/data saidimu/bloomd:v0.7.4
+    docker run -d -p 8673:8673 -v <data-dir>:/data -v <data-dir>/bloomd.conf:/etc/bloomd/bloomd.conf saidimu/bloomd:v0.7.4
     ```
 
 #### Using fig with data-only containers

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bloomd is now listening on port `8673` of your localhost.
 
 #### Attach persistent/shared directories using host-mounted volumes
 
-  1. Create a mountable data directory `<data-dir>` on the host.
+  1. Create a mountable data directory `$DATA_DIR` on the host.
 
   2. Create a [bloomd config file](https://github.com/armon/bloomd#configuration-options) at `$DATA_DIR/bloomd.conf`.
 


### PR DESCRIPTION
1. Fix loading custom conf file to docker - the container uses `/etc/bloomd/bloomd.conf` but the current command doesn't set it up and thus bloomd ignores the users's conf file.
2. Fix docker port - when using docker with `-p 8673` docker chooses a random port on the host. After this fix the host port is constant at 8673.  